### PR TITLE
Apply initial brightness before watching for changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,10 @@ fn main() {
         .watch(&current_brightness_path, RecursiveMode::NonRecursive)
         .expect("Could not create a watcher.");
 
+    if let Err(e) = update_brightness(&opts) {
+        eprintln!("Error applying initial brightness: {}", e);
+    }
+
     println!("Watching {} for backlight changes…", opts.base_path);
     loop {
         match brightness_changes.recv() {


### PR DESCRIPTION
This patch syncs the actual OLED display brightness with the brightness file state before watching for changes. I forked and wrote the patch so that I wouldn't get blasted with ultra-bright OLED display light when rebooting at night. It's also nice to see the display step gracefully from initial state instead of jumping from full-bright on the first keypress.